### PR TITLE
Prevent `WORKER TIMEOUT` issues on Docker 20.x 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN \
     jpeg-dev \
     libffi-dev \
     postgresql-dev \
-    python3-dev && \
+    python3-dev \
+    zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,7 +15,8 @@ RUN \
     jpeg-dev \
     libffi-dev \
     postgresql-dev \
-    python3-dev && \
+    python3-dev \
+    zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,7 +15,8 @@ RUN \
     jpeg-dev \
     libffi-dev \
     postgresql-dev \
-    python3-dev && \
+    python3-dev \
+    zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,4 +39,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.07.21:", desc: "Update Gunicorn parameters to prevent `WORKER_TIMEOUT` issue." }
   - { date: "22.06.21:", desc: "Initial release." }

--- a/root/etc/services.d/babybuddy/run
+++ b/root/etc/services.d/babybuddy/run
@@ -10,4 +10,6 @@ export \
     SECRET_KEY="${SECRET_KEY:-`cat /config/.secretkey`}"
 
 exec \
-    s6-setuidgid abc gunicorn babybuddy.wsgi -b :8000 --log-level=info
+    s6-setuidgid abc gunicorn babybuddy.wsgi -b :8000 --log-level=info \
+        --worker-tmp-dir=/dev/shm --log-file=- \
+        --workers=2 --threads=4 --worker-class=gthread


### PR DESCRIPTION
A user of Baby Buddy ran in to babybuddy/babybuddy#227 and researched and texted a fix that I merged in to the existing Baby Buddy Docker Compose examples in babybuddy/babybuddy#228. This change is based on [Configuring Gunicorn for Docker](https://pythonspeed.com/articles/gunicorn-in-docker/) and the original reported has tested and confirmed that it fixes the issue.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-babybuddy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Quoting from [Configuring Gunicorn for Docker](https://pythonspeed.com/articles/gunicorn-in-docker/):

> Gunicorn’s main process starts one or more worker processes, and restarts them if they die. To ensure the workers are still alive, Gunicorn has a heartbeat system—which works by using a file on the filesystem. Gunicorn therefore recommends that this file be stored in a memory-only part of the filesystem.
>
> As the Gunicorn FAQ explains, the default directory for the heartbeat file is in /tmp, which in some Linux distributions is stored in memory via tmpfs filesystem. Docker containers, however, do not have /tmp on tmpfs by default
>
> [...]
>
>  [...] so what should you do? One option is to mount a tmpfs or ramfs in-memory filesystem onto /tmp, using Docker’s volume support. This will work, but not everywhere: not all environments that run Docker containers support arbitrary volumes.
>
> A more general solution is to tell Gunicorn to store its temporary file elsewhere. In particular, [...] /dev/shm uses the shm filesystem—shared memory, and in-memory filesystem.
>
> **So all you need to do is tell Gunicorn to use /dev/shm instead of /tmp.**

## Benefits of this PR and context:

Using this configuration appears to prevent 30-second long blocking issues in the Baby Buddy application due to `WORKER_TIMEOUT` issues from Gunicorn. See babybuddy/babybuddy#227 for detailed tracking and troubleshooting for the issue by the original PR author.

## How Has This Been Tested?

This has been tested by the original reporter and author of the fix in the base Baby Buddy repo. The fix has been confirmed there and I have also confirmed that I am able to run the Docker Compose setup from the base application repo. I have **not** tested or confirmed yet using the LSIO images.

## Source / References:

- [Initial discussion in Baby Buddy Gitter](https://gitter.im/babybuddy/Lobby?at=60d4adb16c992105fd994cee)
- babybuddy/babybuddy#227
- babybuddy/babybuddy#228
- [Configuring Gunicorn for Docker](https://pythonspeed.com/articles/gunicorn-in-docker/)
