### PR TITLE
Add BABYBUDDY_REPO arg for creating docker images of forks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:3.14
 ARG BUILD_DATE
 ARG VERSION
 ARG BABYBUDDY_VERSION
+ARG BABYBUDDY_REPO
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -24,13 +25,16 @@ RUN \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \
+  if [ -z ${BABYBUDDY_REPO+x} ]; then \
+    BABYBUDDY_REPO="babybuddy/babybuddy"; \
+  fi && \
   if [ -z ${BABYBUDDY_VERSION+x} ]; then \
-    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/babybuddy/babybuddy/releases/latest" \
+    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/${BABYBUDDY_REPO}/releases/latest" \
       | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   curl -o \
     /tmp/babybuddy.tar.gz -L \
-    "https://github.com/babybuddy/babybuddy/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
+    "https://github.com/${BABYBUDDY_REPO}/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
   mkdir -p /app/babybuddy && \
   tar xf \
     /tmp/babybuddy.tar.gz -C \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,6 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.14
 ARG BUILD_DATE
 ARG VERSION
 ARG BABYBUDDY_VERSION
+ARG BABYBUDDY_REPO
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -24,13 +25,16 @@ RUN \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \
+  if [ -z ${BABYBUDDY_REPO+x} ]; then \
+    BABYBUDDY_REPO="babybuddy/babybuddy"; \
+  fi && \
   if [ -z ${BABYBUDDY_VERSION+x} ]; then \
-    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/babybuddy/babybuddy/releases/latest" \
+    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/${BABYBUDDY_REPO}/releases/latest" \
       | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   curl -o \
     /tmp/babybuddy.tar.gz -L \
-    "https://github.com/babybuddy/babybuddy/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
+    "https://github.com/${BABYBUDDY_REPO}/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
   mkdir -p /app/babybuddy && \
   tar xf \
     /tmp/babybuddy.tar.gz -C \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,6 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.14
 ARG BUILD_DATE
 ARG VERSION
 ARG BABYBUDDY_VERSION
+ARG BABYBUDDY_REPO
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -24,13 +25,16 @@ RUN \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \
+  if [ -z ${BABYBUDDY_REPO+x} ]; then \
+    BABYBUDDY_REPO="babybuddy/babybuddy"; \
+  fi && \
   if [ -z ${BABYBUDDY_VERSION+x} ]; then \
-    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/babybuddy/babybuddy/releases/latest" \
+    BABYBUDDY_VERSION=$(curl -sX GET "https://api.github.com/repos/${BABYBUDDY_REPO}/releases/latest" \
       | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   curl -o \
     /tmp/babybuddy.tar.gz -L \
-    "https://github.com/babybuddy/babybuddy/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
+    "https://github.com/${BABYBUDDY_REPO}/archive/refs/tags/${BABYBUDDY_VERSION}.tar.gz" && \
   mkdir -p /app/babybuddy && \
   tar xf \
     /tmp/babybuddy.tar.gz -C \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-babybuddy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This change allows, when building or testing locally, to use a *fork* of the original repository. This is done by giving `docker build` the argument `--build-arg BABYBUDDY_REPO=yourusername/babybuddy`.

## Benefits of this PR and context:

When working on babybuddy (in a forked repository), some changes would properly be tested in a docker container - ideally built the same way as the production one - before sending the pull request to https://github.com/babybuddy/babybuddy. This allows developers to do this.

## How Has This Been Tested?

I have run the `docker build` command with `--build-arg BABYBUDDY_REPO=lutzky/babybuddy --build-arg BABYBUDDY_VERSION=v1.8.0-beta`. The generate container runs fine and includes the latest changes from https://github.com/babybuddy/babybuddy.

## Source / References:

Asked here first: https://discord.com/channels/354974912613449730/506828136869265408/864251741208576010