### PR TITLE
add lxml deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN \
   cd /app/babybuddy && \
   pip3 install -U --no-cache-dir \
     pip && \
+  pip install lxml --no-binary :all: && \
   pip install -U --ignore-installed --find-links https://wheel-index.linuxserver.io/alpine/ -r requirements.txt && \
   echo "**** cleanup ****" && \
   apk del --purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libxml2-dev \
+    libxslt-dev \
     postgresql-dev \
     python3-dev \
     zlib-dev && \
@@ -22,6 +24,8 @@ RUN \
     jpeg \
     libffi \
     libpq \
+    libxml2 \
+    libxslt \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,6 +14,8 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libxml2-dev \
+    libxslt-dev \
     postgresql-dev \
     python3-dev \
     zlib-dev && \
@@ -22,6 +24,8 @@ RUN \
     jpeg \
     libffi \
     libpq \
+    libxml2 \
+    libxslt \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,6 +14,8 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libxml2-dev \
+    libxslt-dev \
     postgresql-dev \
     python3-dev \
     zlib-dev && \
@@ -22,6 +24,8 @@ RUN \
     jpeg \
     libffi \
     libpq \
+    libxml2 \
+    libxslt \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **14.11.21:** - Add lxml dependencies.
 * **25.07.21:** - Add libpq for postgresql.
 * **08.07.21:** - Fix pip install issue.
 * **05.07.21:** - Update Gunicorn parameters to prevent `WORKER_TIMEOUT` issue.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **14.11.21:** - Add lxml dependencies.
+* **14.11.21:** - Add lxml dependencies (temp fix for amd64 by force compiling lxml).
 * **25.07.21:** - Add libpq for postgresql.
 * **08.07.21:** - Fix pip install issue.
 * **05.07.21:** - Update Gunicorn parameters to prevent `WORKER_TIMEOUT` issue.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,7 +39,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "14.11.21:", desc: "Add lxml dependencies." }
+  - { date: "14.11.21:", desc: "Add lxml dependencies (temp fix for amd64 by force compiling lxml)." }
   - { date: "25.07.21:", desc: "Add libpq for postgresql." }
   - { date: "08.07.21:", desc: "Fix pip install issue." }
   - { date: "05.07.21:", desc: "Update Gunicorn parameters to prevent `WORKER_TIMEOUT` issue." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "14.11.21:", desc: "Add lxml dependencies." }
   - { date: "25.07.21:", desc: "Add libpq for postgresql." }
   - { date: "08.07.21:", desc: "Fix pip install issue." }
   - { date: "05.07.21:", desc: "Update Gunicorn parameters to prevent `WORKER_TIMEOUT` issue." }


### PR DESCRIPTION
closes #11
closes #10

For lxml, amd64 uses the official wheel provided, named `lxml-4.6.4-cp39-cp39-musllinux_1_1_x86_64.whl`, which doesn't seem to work. Arm32 and aarch64 builds use the lsio built wheels from `https://wheel-index.linuxserver.io` and they work. We'll force amd64 to compile it instead of using the official wheel while we investigate the issue. This will fix the currently broken image for the latest version.