### PR TITLE
Add py3-mysqlclient for mysql/mariadb support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN \
     libpq \
     libxml2 \
     libxslt \
+    py3-mysqlclient \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -26,6 +26,7 @@ RUN \
     libpq \
     libxml2 \
     libxslt \
+    py3-mysqlclient \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,6 +26,7 @@ RUN \
     libpq \
     libxml2 \
     libxslt \
+    py3-mysqlclient \
     py3-pip \
     python3 && \
   echo "**** install babybuddy ****" && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "11.12.21:", desc: "Add py3-mysqlclient for mysql/mariadb." }
   - { date: "14.11.21:", desc: "Add lxml dependencies (temp fix for amd64 by force compiling lxml)." }
   - { date: "25.07.21:", desc: "Add libpq for postgresql." }
   - { date: "08.07.21:", desc: "Fix pip install issue." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-babybuddy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added py3-mysqlclient package dependency for MySQL/MariaDB support.

## Benefits of this PR and context:
Even though BabyBuddy has MySQL support, this docked container has not. This pull request is supposed to fix that.

## How Has This Been Tested?
Was tested locally on my machine. I use BabyBuddy with MariaDB for several months now, so just connected Docker container to the existent database. 

## Source / References:
[MySQL configuration discussion for BabyBuddy](https://github.com/babybuddy/babybuddy/issues/154)
