### PR TITLE
Pass through some proxy related headers to Django for auto header-based signin

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-babybuddy/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-babybuddy/run
@@ -6,7 +6,9 @@ export \
     ALLOWED_HOSTS="${ALLOWED_HOSTS:-*}" \
     TIME_ZONE="${TZ:-UTC}" \
     DEBUG="${DEBUG:-False}" \
-    SECRET_KEY="${SECRET_KEY:-$(cat /config/.secretkey)}"
+    SECRET_KEY="${SECRET_KEY:-$(cat /config/.secretkey)}" \
+    REVERSE_PROXY_AUTH=${REVERSE_PROXY_AUTH:-False} \
+    PROXY_HEADER=${PROXY_HEADER:-""}
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-babybuddy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This is very useful for allowing users to auto-signin based on headers. Removes the run hack needed here: https://github.com/babybuddy/babybuddy/issues/643#issuecomment-2566400204.



## Benefits of this PR and context:
It's very useful when people are using it as an iframe, e.g. in home assistant, you don't want to be logging in every time you're using this tool.

## How Has This Been Tested?
I've tested this locally. Without setting the flags, the tool works without any change in behavior.  However, by setting:
```
REVERSE_PROXY_AUTH=true
PROXY_HEADER=HTTP_X_REMOTE_USER
```
and adding 
```
proxy_set_header X-Remote-User 'yourusername';
```
to the nginx default template, you can allow auto signin of this user. 

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/babybuddy/babybuddy/issues/643#issuecomment-2566400204